### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-git-clone-1-15-git-init

### DIFF
--- a/.konflux/dockerfiles/git-init.Dockerfile
+++ b/.konflux/dockerfiles/git-init.Dockerfile
@@ -29,6 +29,7 @@ LABEL \
       com.redhat.component="openshift-pipelines-git-init-rhel8-container" \
       name="openshift-pipelines/pipelines-git-init-rhel8" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.15::el8" \
       summary="Red Hat OpenShift Pipelines Git-init" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Git-init" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
