### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-git-clone-1-14-git-init

### DIFF
--- a/.konflux/dockerfiles/git-init.Dockerfile
+++ b/.konflux/dockerfiles/git-init.Dockerfile
@@ -34,6 +34,7 @@ LABEL \
       description="Red Hat OpenShift Pipelines Git-init" \
       io.k8s.display-name="Red Hat OpenShift Pipelines Git-init" \
       io.k8s.description="Red Hat OpenShift Pipelines Git-init" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.14::el8" \
       io.openshift.tags="pipelines,tekton,openshift"
 
 RUN groupadd -r -g 65532 nonroot && useradd --no-log-init -r -u 65532 -g nonroot -d /home/git -m nonroot


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
