### PR TITLE
Revert "chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal:latest docker digest to 6fc28bc"

### DIFF
--- a/.konflux/dockerfiles/git-init.Dockerfile
+++ b/.konflux/dockerfiles/git-init.Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_BUILDER=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23
-ARG RUNTIME=registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+ARG RUNTIME=registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:161a4e29ea482bab6048c2b36031b4f302ae81e4ff18b83e61785f40dc576f5d
 
 FROM $GO_BUILDER AS builder
 


### PR DESCRIPTION
Reverts openshift-pipelines/tektoncd-git-clone#530