### PR TITLE
chore: bump version labels to 1.15.4

### DIFF
--- a/.konflux/dockerfiles/git-init.Dockerfile
+++ b/.konflux/dockerfiles/git-init.Dockerfile
@@ -13,7 +13,7 @@ ENV GODEBUG="http2server=0"
 RUN cd image/git-init && go build -ldflags="-X 'knative.dev/pkg/changeset.rev=$(cat HEAD)'" -mod=vendor -v -o /tmp/tektoncd-catalog-git-clone
 
 FROM $RUNTIME
-ARG VERSION=git-init-1.15.3
+ARG VERSION=git-init-1.15.4
 
 ENV BINARY=git-init \
     KO_APP=/ko-app \


### PR DESCRIPTION
Bump ARG VERSION from 1.15.3 to 1.15.4 in git-init.Dockerfile.