### PR TITLE
[release-v1.15.x] Fix UBI 8 base image for aarch64 builds

### DIFF
--- a/.konflux/dockerfiles/git-init.Dockerfile
+++ b/.konflux/dockerfiles/git-init.Dockerfile
@@ -19,7 +19,7 @@ ENV BINARY=git-init \
     KO_APP=/ko-app \
     KO_DATA_PATH=/kodata
 
-RUN dnf install -y openssh-clients git git-lfs shadow-utils
+RUN dnf install -y --nobest openssh-clients git git-lfs shadow-utils
 
 COPY --from=builder /tmp/tektoncd-catalog-git-clone ${KO_APP}/${BINARY}
 COPY head ${KO_DATA_PATH}/HEAD

--- a/.konflux/dockerfiles/git-init.Dockerfile
+++ b/.konflux/dockerfiles/git-init.Dockerfile
@@ -1,6 +1,6 @@
 # Rebuild trigger: 1.15.4 release 2026-02-26 
 ARG GO_BUILDER=registry.access.redhat.com/ubi8/go-toolset:latest
-ARG RUNTIME=registry.redhat.io/ubi8/ubi:latest@sha256:8f757bfe94700eee7d26c885cd16bf3ae9923edf38f984ef3da50d2ce937fc5e
+ARG RUNTIME=registry.redhat.io/ubi8/ubi:latest
 
 FROM $GO_BUILDER AS builder
 

--- a/.konflux/dockerfiles/git-init.Dockerfile
+++ b/.konflux/dockerfiles/git-init.Dockerfile
@@ -10,7 +10,7 @@ COPY .konflux/patches patches/
 RUN set -e; for f in patches/*.patch; do echo ${f}; [[ -f ${f} ]] || continue; git apply ${f}; done
 COPY head HEAD
 ENV GODEBUG="http2server=0"
-RUN cd image/git-init && go build -ldflags="-X 'knative.dev/pkg/changeset.rev=$(cat HEAD)'" -mod=vendor -v -o /tmp/tektoncd-catalog-git-clone
+RUN HEAD_SHA=$(cat HEAD) && cd image/git-init && go build -ldflags="-X 'knative.dev/pkg/changeset.rev='${HEAD_SHA}" -mod=vendor -v -o /tmp/tektoncd-catalog-git-clone
 
 FROM $RUNTIME
 ARG VERSION=1.15
@@ -19,7 +19,7 @@ ENV BINARY=git-init \
     KO_APP=/ko-app \
     KO_DATA_PATH=/kodata
 
-RUN dnf install -y --nobest openssh-clients git git-lfs shadow-utils
+RUN dnf install -y openssh-clients git-core git-lfs shadow-utils
 
 COPY --from=builder /tmp/tektoncd-catalog-git-clone ${KO_APP}/${BINARY}
 COPY head ${KO_DATA_PATH}/HEAD


### PR DESCRIPTION
Drops the pinned UBI 8 digest from git-init.Dockerfile. The pinned image has a broken openssl-libs dependency chain on aarch64, causing all multi-arch builds to fail:

```
nothing provides openssl-libs(aarch-64) = 1:1.1.1k-14.el8_10
needed by openssl-1:1.1.1k-14.el8_10.aarch64
```

Using `ubi8/ubi:latest` without digest pin picks up the current image with fixed repos.